### PR TITLE
Correct typo and website address in TODO

### DIFF
--- a/TODO
+++ b/TODO
@@ -37,8 +37,8 @@ SHORT TERM
 
 - New KVDatabase implementations
     - Amazon DynamoDB ?
-    - Sphia
-        - http://sphia.org/
+    - Sophia
+        - http://sophia.systems/
 
 - key/value layer transaction improvements
     - Add Spring transaction manager


### PR DESCRIPTION
sphia.org is a site pushing medical marijuana oils, sophia.systems is a website pushing a high performance k/v store