### PR TITLE
Miscellaneous typo/JavaDoc fixes, small code simplifications, add IntellliJ files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 /*.patch.gz
 /xx.java
 /xx*.class
+.idea
+*.iml

--- a/permazen-cli/src/main/java/io/permazen/cli/cmd/DecodeKeyCommand.java
+++ b/permazen-cli/src/main/java/io/permazen/cli/cmd/DecodeKeyCommand.java
@@ -386,7 +386,6 @@ public class DecodeKeyCommand extends AbstractKVCommand {
             int off = 0;
             for (Decode decode : this.decodeList) {
                 final int len = decode.getLength();
-                final String byteString;
                 buf.append(String.format(format, this.truncate(reader.getBytes(off, len), byteLimit), decode.getDescription()));
                 off += len;
             }

--- a/permazen-coreapi/src/main/java/io/permazen/core/FieldTypesFilter.java
+++ b/permazen-coreapi/src/main/java/io/permazen/core/FieldTypesFilter.java
@@ -101,7 +101,7 @@ class FieldTypesFilter implements KeyFilter {
 
     /**
      * Create a new instance with the given {@link KeyFilter} applied to encoded field values at the specified index.
-     * This method works cummulatively: if this instance already has a filter for the field, the new instance filters
+     * This method works cumulatively: if this instance already has a filter for the field, the new instance filters
      * to the intersection of the existing filter and the given filter.
      *
      * @param index field index (zero-based)

--- a/permazen-coreapi/src/main/java/io/permazen/core/JSMap.java
+++ b/permazen-coreapi/src/main/java/io/permazen/core/JSMap.java
@@ -66,7 +66,7 @@ class JSMap<K, V> extends FieldTypeMap<K, V> {
 
     private V doPut(final K keyObj, final V newValueObj, byte[] key, byte[] newValue) {
 
-        // Check for deleted assignement of key and/or value
+        // Check for deleted assignment of key and/or value
         if (this.field.keyField instanceof ReferenceField)
             this.tx.checkDeletedAssignment(this.id, (ReferenceField)this.field.keyField, (ObjId)keyObj);
         if (this.field.valueField instanceof ReferenceField)

--- a/permazen-coreapi/src/main/java/io/permazen/core/MapField.java
+++ b/permazen-coreapi/src/main/java/io/permazen/core/MapField.java
@@ -40,7 +40,6 @@ public class MapField<K, V> extends ComplexField<NavigableMap<K, V>> {
     /**
      * Constructor.
      *
-     * @param objType the object type that contains this field
      * @param name the name of the field
      * @param storageId field content storage ID
      * @param schema schema version

--- a/permazen-coreapi/src/main/java/io/permazen/core/Schemas.java
+++ b/permazen-coreapi/src/main/java/io/permazen/core/Schemas.java
@@ -109,9 +109,10 @@ public class Schemas {
      * @param storageId schema object storage ID
      * @param expectedType expected {@link StorageInfo} type
      * @return the actual {@link StorageInfo} instance found
-     * @throws UnknownFieldException if type doesn't match and {@code expectedType} is a {@link FieldStorageInfo} sub-type
+     * @throws UnknownFieldException if type doesn't match and {@code expectedType} is a {@link SimpleFieldStorageInfo}
+     * sub-type
      * @throws UnknownIndexException if type doesn't match and {@code expectedType} is {@link CompositeIndexStorageInfo}
-     * @throws UnknownTypeException if type doesn't match and {@code expectedType} is {@link ObjectStorageInfo}
+     * @throws UnknownTypeException if type doesn't match and {@code expectedType} is {@link ObjTypeStorageInfo}
      */
     <T extends StorageInfo> T verifyStorageInfo(int storageId, Class<T> expectedType) {
         final StorageInfo storageInfo = this.storageInfos.get(storageId);

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/FollowerRole.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/FollowerRole.java
@@ -587,7 +587,7 @@ public class FollowerRole extends NonLeaderRole {
                 try {
                     this.raft.logDirChannel.force(true);
                 } catch (IOException e) {
-                    this.warn("errory fsync()'ing log directory " + this.raft.logDir, e);
+                    this.warn("error fsync()'ing log directory " + this.raft.logDir, e);
                 }
 
                 // Rebuild current config

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/LeaderRole.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/LeaderRole.java
@@ -1058,12 +1058,13 @@ public class LeaderRole extends Role {
     }
 
     /**
-     * Apply a new log entry to the Raft log; if operation fails, {@link NewLogEntry#cancel cancel()} {@code newLogEntry}.
+     * Apply a new log entry to the Raft log.
      *
      * @throws IllegalStateException if a config change would not be safe at the current time
      * @throws IllegalArgumentException if the config change attempts to remove the last node
+     * @throws IOException if there was a disk error whilst persisting the new log entry
      */
-    private LogEntry applyNewLogEntry(NewLogEntry newLogEntry) throws Exception {
+    private LogEntry applyNewLogEntry(NewLogEntry newLogEntry) throws IOException {
         assert Thread.holdsLock(this.raft);
 
         // Do a couple of extra checks if a config change is included

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/Log.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/Log.java
@@ -310,7 +310,7 @@ final class Log {
         // Sanity check
         assert Thread.holdsLock(this.raft);
 
-        // Remove entry from "unapplied list
+        // Remove entry from "unapplied" list
         final LogEntry logEntry = this.unapplied.remove(0);
 
         // Update "last applied" info

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/MostRecentView.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/MostRecentView.java
@@ -26,10 +26,6 @@ class MostRecentView {
     private final HashMap<String, String> config;
     private final MutableView view;
 
-    MostRecentView(final RaftKVDatabase raft) {
-        this(raft, -1);
-    }
-
     MostRecentView(final RaftKVDatabase raft, final long maxIndex) {
 
         // Sanity check

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/NewLogEntry.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/NewLogEntry.java
@@ -12,9 +12,6 @@ import java.io.IOException;
 
 /**
  * Contains the information required to commit a new entry to the log.
- *
- * <p>
- * Instances must be {@link #close}'ed when no longer needed to ensure the temporary file is deleted if not used.
  */
 class NewLogEntry {
 
@@ -29,7 +26,7 @@ class NewLogEntry {
      * @param tx local transaction
      * @param tempFile temporary file containing serialized mutations
      */
-    NewLogEntry(final RaftKVTransaction tx, final File tempFile) throws IOException {
+    NewLogEntry(final RaftKVTransaction tx, final File tempFile) {
         this(new LogEntry.Data(tx.view.getWrites(), tx.getConfigChange()), tempFile);
     }
 

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/Service.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/Service.java
@@ -14,10 +14,6 @@ class Service implements Runnable {
     protected final String desc;
     protected final Runnable action;
 
-    Service(String desc) {
-        this(null, desc, null);
-    }
-
     Service(String desc, Runnable action) {
         this(null, desc, action);
     }

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/Timer.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/Timer.java
@@ -56,7 +56,7 @@ class Timer {
             this.future = null;
         }
 
-        // Ensure the previously scheduled action does nothing if case we lose the cancel() race condition
+        // Ensure the previously scheduled action does nothing in case we lose the cancel() race condition
         this.pendingTimeout = null;
         this.timeoutDeadline = null;
     }
@@ -64,8 +64,7 @@ class Timer {
     /**
      * (Re)schedule this timer. Discards any previously scheduled timeout.
      *
-     * @param delay delay before expiration in milliseonds
-     * @return true if restarted, false if executor rejected the task
+     * @param delay delay before expiration in milliseconds
      * @throws IllegalStateException if the lock object is not locked
      */
     public void timeoutAfter(int delay) {

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/Timestamp.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/Timestamp.java
@@ -39,7 +39,7 @@ public class Timestamp implements Comparable<Timestamp> {
     private final int millis;
 
     /**
-     * Construtor returning the current time.
+     * Constructor returning the current time.
      */
     public Timestamp() {
         this(Timestamp.now());

--- a/permazen-kv-raft/src/main/java/io/permazen/kv/raft/msg/AppendResponse.java
+++ b/permazen-kv-raft/src/main/java/io/permazen/kv/raft/msg/AppendResponse.java
@@ -22,7 +22,7 @@ public class AppendResponse extends Message {
 
     private final Timestamp leaderTimestamp;        // leaderTimestamp from corresponding AppendRequest
     private final boolean success;                  // true if previous log entry term and index matched
-    private final long matchIndex;                  // index of higest log entry known to match leader
+    private final long matchIndex;                  // index of highest log entry known to match leader
     private final long lastLogIndex;                // the index of the last log entry in follower's log
 
 // Constructors

--- a/permazen-kv-simple/src/main/java/io/permazen/kv/simple/SimpleKVDatabase.java
+++ b/permazen-kv-simple/src/main/java/io/permazen/kv/simple/SimpleKVDatabase.java
@@ -177,7 +177,7 @@ public class SimpleKVDatabase implements KVDatabase, Serializable {
     /**
      * Set the hold timeout for this instance. Default is {@link #DEFAULT_HOLD_TIMEOUT}.
      *
-     * @param holdTimeout how long a thread may hold a contestested lock before throwing {@link RetryTransactionException}
+     * @param holdTimeout how long a thread may hold a contested lock before throwing {@link RetryTransactionException}
      *  in milliseconds, or zero for unlimited
      * @throws IllegalArgumentException if {@code holdTimeout} is negative
      */

--- a/permazen-kv/src/main/java/io/permazen/kv/mvcc/LockManager.java
+++ b/permazen-kv/src/main/java/io/permazen/kv/mvcc/LockManager.java
@@ -99,7 +99,7 @@ public class LockManager {
     /**
      * Set the hold timeout for this instance. Default is zero (unlimited).
      *
-     * @param holdTimeout how long a thread may hold a contestested lock before {@link LockResult#HOLD_TIMEOUT_EXPIRED}
+     * @param holdTimeout how long a thread may hold a contested lock before {@link LockResult#HOLD_TIMEOUT_EXPIRED}
      *  will be returned by {@link #lock lock()} or {@link #release release()} in milliseconds, or zero for unlimited
      * @throws IllegalArgumentException if {@code holdTimeout} is negative
      */
@@ -240,7 +240,7 @@ public class LockManager {
         Preconditions.checkArgument(owner != null, "null owner");
         synchronized (this.lockObject) {
 
-            // Check if hold timeout has alread expired; in any case, remove lock time
+            // Check if hold timeout has already expired; in any case, remove lock time
             if (this.lockTimes.containsKey(owner)) {
                 final Long lockTime = this.lockTimes.remove(owner);
                 if (lockTime == null)

--- a/permazen-kv/src/main/java/io/permazen/kv/mvcc/MutableView.java
+++ b/permazen-kv/src/main/java/io/permazen/kv/mvcc/MutableView.java
@@ -45,7 +45,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * <p>
  * During construction, instances may be configured to record all keys read into a {@link Reads} object (this is typically
  * used for MVCC conflict detection). When reads are being tracked, tracking may temporarily be paused and resumed via
- * {@link #setReadTrackingPaused}. Read tracking may be permanently disabled (and any recorded reads discareded) via
+ * {@link #setReadTrackingPaused}. Read tracking may be permanently disabled (and any recorded reads discarded) via
  * {@link #disableReadTracking}.
  *
  * <p>

--- a/permazen-kv/src/main/java/io/permazen/kv/mvcc/ReadRemoveConflict.java
+++ b/permazen-kv/src/main/java/io/permazen/kv/mvcc/ReadRemoveConflict.java
@@ -16,7 +16,7 @@ import io.permazen.kv.KeyRange;
  * <p>
  * Instances are immutable.
  *
- * @see Reads#getAllConflicts Reads.getAllConflicts()
+ * @see Reads#getAllConflicts(Mutations)  Reads.getAllConflicts(Mutations)
  */
 public class ReadRemoveConflict extends Conflict {
 

--- a/permazen-main/src/main/java/io/permazen/ClassGenerator.java
+++ b/permazen-main/src/main/java/io/permazen/ClassGenerator.java
@@ -422,7 +422,7 @@ class ClassGenerator<T> {
         mv.visitMaxs(0, 0);
         mv.visitEnd();
 
-        // Add JOBject.resetCachedFieldValues()
+        // Add JObject.resetCachedFieldValues()
         mv = this.startMethod(cw, JOBJECT_RESET_CACHED_FIELD_VALUES_METHOD);
         mv.visitCode();
         if (this.jclass != null) {
@@ -608,15 +608,6 @@ class ClassGenerator<T> {
         for (Class<?> type : method.getExceptionTypes())
             list.add(Type.getType(type).getInternalName());
         return list.toArray(new String[list.size()]);
-    }
-
-    // Callback interface for emitting bytecode
-    interface CodeEmitter {
-
-        /**
-         * Output some method bytecode or whatever.
-         */
-        void emit(MethodVisitor mv);
     }
 
 // Cached value flags field(s)

--- a/permazen-main/src/main/java/io/permazen/ConvertedJSimpleField.java
+++ b/permazen-main/src/main/java/io/permazen/ConvertedJSimpleField.java
@@ -20,7 +20,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 /**
- * Support superclass for {@link JSimpleField}'s that require convertion between Java and core API values.
+ * Support superclass for {@link JSimpleField}'s that require conversion between Java and core API values.
  */
 abstract class ConvertedJSimpleField<A, B> extends JSimpleField {
 

--- a/permazen-main/src/main/java/io/permazen/DefaultStorageIdGenerator.java
+++ b/permazen-main/src/main/java/io/permazen/DefaultStorageIdGenerator.java
@@ -10,7 +10,7 @@ import io.permazen.core.MapField;
 import io.permazen.core.SetField;
 
 import java.lang.reflect.Method;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -74,7 +74,7 @@ public class DefaultStorageIdGenerator implements StorageIdGenerator {
 
     private int getStorageId(String string) {
         this.sha1.reset();
-        final byte[] digest = this.sha1.digest(string.getBytes(Charset.forName("UTF-8")));
+        final byte[] digest = this.sha1.digest(string.getBytes(StandardCharsets.UTF_8));
         int value = 0;
         for (int i = 0; i < 4; i++)
             value = (value << 8) | (digest[i] & 0xff);

--- a/permazen-main/src/main/java/io/permazen/JObject.java
+++ b/permazen-main/src/main/java/io/permazen/JObject.java
@@ -19,7 +19,7 @@ import java.util.NavigableSet;
  * <p>
  * All {@link Permazen} database objects are instances of runtime-generated sub-classes of user-provided Java model types.
  * These generated subclasses will always implement this interface, providing convenient access to database operations.
- * Therefore, it is conveninent to declare Java model classes {@code abstract} and {@code implements JObject}.
+ * Therefore, it is convenient to declare Java model classes {@code abstract} and {@code implements JObject}.
  * However, this is not strictly necessary; all of the methods declared here ultimately delegate to one of the
  * {@link JTransaction} support methods.
  *
@@ -112,7 +112,7 @@ public interface JObject {
      * with a {@link SnapshotJTransaction}.
      *
      * <p>
-     * Equvialent to {@code getTransaction().isSnapshot()}.
+     * Equivalent to {@code getTransaction().isSnapshot()}.
      *
      * @return true if instance is a snapshot instance
      */

--- a/permazen-main/src/main/java/io/permazen/JObjectCache.java
+++ b/permazen-main/src/main/java/io/permazen/JObjectCache.java
@@ -187,7 +187,7 @@ class JObjectCache {
     }
 
     /**
-     * Create the {@lin JObject} for the given object ID.
+     * Create the {@link JObject} for the given object ID.
      *
      * <p>
      * Put an entry in this thread's instantiation map while doing so.

--- a/permazen-main/src/main/java/io/permazen/JSimpleField.java
+++ b/permazen-main/src/main/java/io/permazen/JSimpleField.java
@@ -16,10 +16,7 @@ import io.permazen.core.ObjId;
 import io.permazen.schema.SimpleSchemaField;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 import org.dellroad.stuff.java.Primitive;
 import org.objectweb.asm.ClassWriter;
@@ -185,7 +182,7 @@ public class JSimpleField extends JField {
             return false;
         if (this.unique != that.unique)
             return false;
-        if (!(this.uniqueExcludes != null ? this.uniqueExcludes.equals(that.uniqueExcludes) : that.uniqueExcludes == null))
+        if (!(Objects.equals(this.uniqueExcludes, that.uniqueExcludes)))
             return false;
         if (!this.upgradeConversion.equals(that.upgradeConversion))
             return false;

--- a/permazen-main/src/main/java/io/permazen/JTransaction.java
+++ b/permazen-main/src/main/java/io/permazen/JTransaction.java
@@ -54,18 +54,7 @@ import io.permazen.util.CloseableIterator;
 import io.permazen.util.ConvertedNavigableMap;
 import io.permazen.util.ConvertedNavigableSet;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.NavigableSet;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -137,7 +126,7 @@ import org.slf4j.LoggerFactory;
  *  <li>{@link #queryIndex(Class, String, Class) queryIndex()}
  *      - Access the index associated with a simple field</li>
  *  <li>{@link #queryListElementIndex queryListElementIndex()}
- *      - Access the composite index associated with a list field that includes corresponding list indicies</li>
+ *      - Access the composite index associated with a list field that includes corresponding list indices</li>
  *  <li>{@link #queryMapValueIndex queryMapValueIndex()}
  *      - Access the composite index associated with a map value field that includes corresponding map keys</li>
  *  <li>{@link #queryCompositeIndex(Class, String, Class, Class) queryCompositeIndex()}
@@ -402,7 +391,7 @@ public class JTransaction {
      * <p>
      * Notes:
      * <ul>
-     *  <li>Objects utilize mutiple keys; the return value is the common prefix of all such keys.</li>
+     *  <li>Objects utilize multiple keys; the return value is the common prefix of all such keys.</li>
      *  <li>The {@link io.permazen.kv.KVDatabase} should not be modified directly, otherwise behavior is undefined</li>
      * </ul>
      *
@@ -423,7 +412,7 @@ public class JTransaction {
      * <p>
      * Notes:
      * <ul>
-     *  <li>Complex fields utilize mutiple keys; the return value is the common prefix of all such keys.</li>
+     *  <li>Complex fields utilize multiple keys; the return value is the common prefix of all such keys.</li>
      *  <li>The {@link io.permazen.kv.KVDatabase} should not be modified directly, otherwise behavior is undefined</li>
      * </ul>
      *
@@ -466,7 +455,7 @@ public class JTransaction {
      *
      * <p>
      * This instance must not itself be a {@link SnapshotJTransaction}; use
-     * {@link createSnapshotTransaction createSnapshotTransaction()} to create additional snapshot transactions.
+     * {@link #createSnapshotTransaction createSnapshotTransaction()} to create additional snapshot transactions.
      *
      * @return the associated snapshot transaction
      * @see JObject#copyOut JObject.copyOut()
@@ -684,7 +673,7 @@ public class JTransaction {
      */
     public void copyTo(JTransaction dest, CopyState copyState, Stream<? extends JObject> jobjs) {
         this.copyIdStreamTo(dest, copyState, jobjs
-          .filter(jobj -> jobj != null)
+          .filter(Objects::nonNull)
           .peek(JTransaction::registerJObject)                              // handle possible re-entrant object cache load
           .map(JObject::getObjId));
     }
@@ -1458,7 +1447,7 @@ public class JTransaction {
     }
 
     /**
-     * Get the composite index on a list field that includes list indicies.
+     * Get the composite index on a list field that includes list indices.
      *
      * @param targetType type containing the indexed field; may also be any super-type (e.g., an interface type),
      *  as long as {@code fieldName} is not ambiguous among all sub-types
@@ -1466,7 +1455,7 @@ public class JTransaction {
      * @param valueType the Java type corresponding to list elements
      * @param <V> Java type corresponding to the indexed list's element field
      * @param <T> Java type containing the field
-     * @return read-only, real-time view of field values, objects having that value in the field, and corresponding list indicies
+     * @return read-only, real-time view of field values, objects having that value in the field, and corresponding list indices
      * @throws IllegalArgumentException if any parameter is null, or invalid
      * @throws StaleTransactionException if this transaction is no longer usable
      */

--- a/permazen-main/src/main/java/io/permazen/StorageIdGenerator.java
+++ b/permazen-main/src/main/java/io/permazen/StorageIdGenerator.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Method;
 public interface StorageIdGenerator {
 
     /**
-     * Generage a storage ID for a Java model class.
+     * Generate a storage ID for a Java model class.
      *
      * @param type Java model class
      * @param typeName database type name
@@ -26,7 +26,7 @@ public interface StorageIdGenerator {
     int generateClassStorageId(Class<?> type, String typeName);
 
     /**
-     * Generage a storage ID for a composite index.
+     * Generate a storage ID for a composite index.
      *
      * @param type Java model class containing the indexed fields
      * @param name composite index name
@@ -36,7 +36,7 @@ public interface StorageIdGenerator {
     int generateCompositeIndexStorageId(Class<?> type, String name, int[] fields);
 
     /**
-     * Generage a storage ID for a regular top-level field (i.e., a field that is not a sub-field of a complex field).
+     * Generate a storage ID for a regular top-level field (i.e., a field that is not a sub-field of a complex field).
      *
      * @param getter the field's Java bean getter method
      * @param name the field's database name
@@ -45,7 +45,7 @@ public interface StorageIdGenerator {
     int generateFieldStorageId(Method getter, String name);
 
     /**
-     * Generage a storage ID for a set field.
+     * Generate a storage ID for a set field.
      *
      * @param getter the set field's Java bean getter method
      * @param name the set element field's database name
@@ -54,7 +54,7 @@ public interface StorageIdGenerator {
     int generateSetElementStorageId(Method getter, String name);
 
     /**
-     * Generage a storage ID for a list field.
+     * Generate a storage ID for a list field.
      *
      * @param getter the list field's Java bean getter method
      * @param name the list element field's database name
@@ -63,7 +63,7 @@ public interface StorageIdGenerator {
     int generateListElementStorageId(Method getter, String name);
 
     /**
-     * Generage a storage ID for a map key field.
+     * Generate a storage ID for a map key field.
      *
      * @param getter the map field's Java bean getter method
      * @param name the map key field's database name
@@ -72,7 +72,7 @@ public interface StorageIdGenerator {
     int generateMapKeyStorageId(Method getter, String name);
 
     /**
-     * Generage a storage ID for a map value field.
+     * Generate a storage ID for a map value field.
      *
      * @param getter the map field's Java bean getter method
      * @param name the map value field's database name

--- a/permazen-main/src/main/java/io/permazen/annotation/OnChange.java
+++ b/permazen-main/src/main/java/io/permazen/annotation/OnChange.java
@@ -12,7 +12,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for methods that are to be invoked whenever a simple or complext target field in some target object changes
+ * Annotation for methods that are to be invoked whenever a simple or complex target field in some target object changes
  * during a transaction, where the target object containing the changed field is found at the end of a path of references
  * starting from the object to be notified.
  * See {@link io.permazen.ReferencePath} for more information about reference paths.
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
  * <ul>
  *  <li>By specifying a path of object references, via {@link #value}, to the target object and field</li>
  *  <li>By widening or narrowing the type of the {@link io.permazen.change.FieldChange} method parameter
- *      (or omitting it algtogether)</li>
+ *      (or omitting it altogether)</li>
  *  <li>By declaring an instance method, to monitor changes from the perspective of the associated object,
  *      or a static method, to monitor changes from a global perspective</li>
  *  <li>By {@linkplain #snapshotTransactions allowing or disallowing} notifications that occur within
@@ -143,7 +143,7 @@ import java.lang.annotation.Target;
  * <p>
  * Multiple reference paths may be specified; if so, all of the specified paths are monitored together, and they all
  * must emit {@link io.permazen.change.FieldChange}s compatible with the method's parameter type. Therefore, when
- * mutiple fields are monitored, the method's parameter type may need to be widened (either in raw type, generic type
+ * multiple fields are monitored, the method's parameter type may need to be widened (either in raw type, generic type
  * parameters, or both).
  *
  * <p>

--- a/permazen-parse/src/main/java/io/permazen/parse/func/QueryListElementIndexFunction.java
+++ b/permazen-parse/src/main/java/io/permazen/parse/func/QueryListElementIndexFunction.java
@@ -24,7 +24,7 @@ public class QueryListElementIndexFunction extends AbstractQueryFunction {
 
     @Override
     public String getHelpSummary() {
-        return "Queries the composite index on a list element field that includes the list indicies";
+        return "Queries the composite index on a list element field that includes the list indices";
     }
 
     @Override

--- a/permazen-util/src/main/java/io/permazen/index/package-info.java
+++ b/permazen-util/src/main/java/io/permazen/index/package-info.java
@@ -20,7 +20,7 @@
  *  <li>{@link io.permazen.JTransaction#queryIndex(Class, String, Class) JTransaction.queryIndex()}
  *      - Access the index associated with a simple field</li>
  *  <li>{@link io.permazen.JTransaction#queryListElementIndex JTransaction.queryListElementIndex()}
- *      - Access the composite index associated with a list field that includes corresponding list indicies</li>
+ *      - Access the composite index associated with a list field that includes corresponding list indices</li>
  *  <li>{@link io.permazen.JTransaction#queryMapValueIndex JTransaction.queryMapValueIndex()}
  *      - Access the composite index associated with a map value field that includes corresponding map keys</li>
  *  <li>{@link io.permazen.JTransaction#queryCompositeIndex(Class, String, Class, Class) JTransaction.queryCompositeIndex()}

--- a/permazen-util/src/main/java/io/permazen/util/Bounds.java
+++ b/permazen-util/src/main/java/io/permazen/util/Bounds.java
@@ -243,10 +243,8 @@ public class Bounds<T> {
         if (newBounds.lowerBoundType != BoundType.NONE
           && !this.isWithinBound(comparator, newBounds.lowerBound, newBounds.lowerBoundType.isInclusive(), false))
             return false;
-        if (newBounds.upperBoundType != BoundType.NONE
-          && !this.isWithinBound(comparator, newBounds.upperBound, newBounds.upperBoundType.isInclusive(), true))
-            return false;
-        return true;
+        return newBounds.upperBoundType == BoundType.NONE
+                || this.isWithinBound(comparator, newBounds.upperBound, newBounds.upperBoundType.isInclusive(), true);
     }
 
     /**
@@ -256,8 +254,6 @@ public class Bounds<T> {
      * @param value value to check
      * @param requireInclusive whether value should not be considered included when it is exactly equal to an exclusive bound
      * @param upper true to check against upper bound, false to check against lower bound
-     * @throws IllegalArgumentException if {@link newBound} is out of range
-     * @throws IllegalArgumentException if {@link newBoundType} is null
      */
     @SuppressWarnings("unchecked")
     private boolean isWithinBound(Comparator<? super T> comparator, T value, boolean requireInclusive, boolean upper) {
@@ -273,9 +269,7 @@ public class Bounds<T> {
 
         // Handle value equal to bound
         if (diff == 0) {
-            if (boundType == BoundType.INCLUSIVE || !requireInclusive)
-                return true;
-            return false;
+            return boundType == BoundType.INCLUSIVE || !requireInclusive;
         }
 
         // Value is either inside or outside bound

--- a/permazen-util/src/main/java/io/permazen/util/ConvertedNavigableMap.java
+++ b/permazen-util/src/main/java/io/permazen/util/ConvertedNavigableMap.java
@@ -16,7 +16,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
- * Provides a transformed view of a wrapped {@link NavigableMap} using a strictly invertable {@link Converter}.
+ * Provides a transformed view of a wrapped {@link NavigableMap} using a strictly invertible {@link Converter}.
  *
  * <p>
  * Supplied {@link Converter}s may throw {@link ClassCastException} or {@link IllegalArgumentException}


### PR DESCRIPTION
I've spent a lot of time over the holiday break reading and understanding some of the Permazen code. As part of that I fixed a bunch of typos, broken JavaDocs etc that IntelliJ flagged. I also accepted a few of its suggestions for code simplification, albeit not most of them to avoid too much pointless churn.

Where code has been deleted it's because it's dead. I left most dead methods as they may be useful in future, but some stuff would clearly never be used.